### PR TITLE
DD-1820 dd-dataverse-ingest-cli: java.net.SocketTimeoutException: Read timed out

### DIFF
--- a/src/main/assembly/dist/cfg/example-config.yml
+++ b/src/main/assembly/dist/cfg/example-config.yml
@@ -2,7 +2,7 @@ dataverseIngest:
   url: "http://localhost:20360"
   httpClient:
     connectTimeout: 15s
-    readTimeout: 60s
+    timeout: 30s
 
 
 #


### PR DESCRIPTION
Fixes DD-1820

# Description of changes
Replaced the non-existent property dataverseIngest.httpClient.readTimeout with dataverseIngest.httpClient.timeout and set it to 30s. This should be enough for the service to send a response. The default of 500ms is sometimes too short.

# How to test
Set `timeout` so something ridiculously low like 1ms and observe that all calls fail with the `java.net.SocketTimeoutException: Read timed out` exception. Now set it back to 30s and see that this resolves the issue.


# Notify
@DANS-KNAW/core-systems
